### PR TITLE
feat: add GitHub Action to sync fork with upstream

### DIFF
--- a/.github/workflows/sync-fork-with-upstream.yml
+++ b/.github/workflows/sync-fork-with-upstream.yml
@@ -1,0 +1,18 @@
+name: Sync Fork with Upstream
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs every day at midnight UTC
+  workflow_dispatch: {} # Allows manual triggering
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync fork
+        uses: repo-sync/fork-sync@v2
+        with:
+          upstream_repository: 'elizaOS/eliza'
+          upstream_branch: 'develop'
+          target_branch: 'develop'
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds a new GitHub Action workflow that automatically syncs the 'develop' branch with the upstream repository 'elizaOS/eliza'.

The sync runs daily at midnight UTC and can also be triggered manually.